### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11954,5 +11954,12 @@
         "author": "Charles Young",
         "description": "Track the time between log entries.",
         "repo": "agctute/relative-timestamps"
-  }
+    },
+    {
+        "id": "copy-previous-day-note",
+        "name": "Copy Previous Day Note",
+        "author": "José Feiteirinha",        
+        "description": "Copies the previous day's note when creating a new daily note.",
+        "repo": "feiteira/obsidian-copy-previous-day-note"
+    }    
 ]


### PR DESCRIPTION
Adds plugin copy-previous-day-note (https://github.com/feiteira/obsidian-copy-previous-day-note)

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
